### PR TITLE
Forbade usage of function with an error union return type

### DIFF
--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4,4 +4,7 @@ test "interface" {
     testing.refAllDecls(@import("tests/basic.zig"));
     testing.refAllDecls(@import("tests/circular_reference.zig"));
     testing.refAllDecls(@import("tests/to_string.zig"));
+
+    //This test below should fail to compile because it has a function with an inferred error set
+    //testing.refAllDecls(@import("tests/to_string_error.zig"));
 }

--- a/src/tests/to_string_error.zig
+++ b/src/tests/to_string_error.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+const testing = std.testing;
+const interface = @import("interface");
+
+//=============Code to create the interface=============
+fn MakePrintable(comptime BaseType: type) type {
+    return struct {
+        pub inline fn to_string(self: BaseType, a: std.mem.Allocator) ![]u8 {
+            return self.vtable.to_string(self.object, a);
+        }
+    };
+}
+// makeInterface creates an interface type that can be used to create implementations
+const Printable = interface.MakeInterface(MakePrintable, .{});
+
+//==============Code to create a type which implements the interface==========
+const SubType = struct {
+    foo: i32,
+    bar: i32,
+
+    pub fn to_string(self: @This(), a: std.mem.Allocator) ![]u8 {
+        return try std.fmt.allocPrint(a, "[foo: {}, bar: {}]", .{ self.foo, self.bar });
+    }
+};
+
+//==============Code to create a function which accepts the interface type===========
+fn doSomething(a: std.mem.Allocator, printable: Printable) !void {
+    const string = try printable.to_string(a);
+    defer a.free(string);
+    std.debug.print("{s}", .{string});
+}
+
+test "printable interface" {
+    var sub_type_value = SubType{ .foo = 123, .bar = 456 };
+    var sub_type_interface = Printable.initFromImplementer(SubType, &sub_type_value);
+
+    const stringified = try sub_type_interface.to_string(std.testing.allocator);
+    defer std.testing.allocator.free(stringified);
+
+    try doSomething(std.testing.allocator, sub_type_interface);
+}


### PR DESCRIPTION
Possible way of fixing #3 

This however has the downside that all error union functions are now disallowed. I don't think there is a way to tell whether an error set is in inferred or not

I've included an example file which will panic during compilation before this change, whereas now it gives you a proper error message and diagnostic. 

Up to the library maintainers whether this is an appropriate trade off or not.

